### PR TITLE
Add cli component

### DIFF
--- a/action.php
+++ b/action.php
@@ -81,7 +81,6 @@ class action_plugin_cleanoldips extends DokuWiki_Action_Plugin
                 continue;
             }
 
-            touch($this->getOurCacheFilename($mediaID));
             $this->cleanChangelog($mediaID, $changelogFN);
         }
     }
@@ -96,7 +95,7 @@ class action_plugin_cleanoldips extends DokuWiki_Action_Plugin
     {
         global $conf;
 
-        $cacheFile = $this->getOurCacheFilename($id);
+        $cacheFile = $this->getOurCacheFilename($id, true);
         $cacheStartPosition = (int)file_get_contents($cacheFile);
         $startPosition = $this->validateStartPosition($cacheStartPosition, $changelogFN);
 
@@ -157,11 +156,16 @@ class action_plugin_cleanoldips extends DokuWiki_Action_Plugin
      * Get the filename of this plugin's cachefile for a page
      *
      * @param string $pageid full id of the page
+     * @param bool   $create create the cache file if it doesn't exists
      *
      * @return string the filename of this plugin's cachefile
      */
-    protected function getOurCacheFilename($pageid)
+    protected function getOurCacheFilename($pageid, $create = false)
     {
-        return getCacheName($pageid . 'cleanoldips');
+        $cacheFN = getCacheName('_' . $pageid . 'cleanoldips');
+        if ($create && !file_exists($cacheFN)) {
+            touch($cacheFN);
+        }
+        return $cacheFN;
     }
 }

--- a/action.php
+++ b/action.php
@@ -93,6 +93,9 @@ class action_plugin_cleanoldips extends DokuWiki_Action_Plugin
      */
     protected function cleanChangelog($id, $changelogFN)
     {
+        if (!file_exists($changelogFN)) {
+            return;
+        }
         global $conf;
 
         $cacheFile = $this->getOurCacheFilename($id, true);

--- a/action.php
+++ b/action.php
@@ -91,7 +91,7 @@ class action_plugin_cleanoldips extends DokuWiki_Action_Plugin
      * @param string $id
      * @param string $changelogFN
      */
-    protected function cleanChangelog($id, $changelogFN)
+    public function cleanChangelog($id, $changelogFN)
     {
         if (!file_exists($changelogFN)) {
             return;

--- a/cli.php
+++ b/cli.php
@@ -39,6 +39,7 @@ class cli_plugin_cleanoldips extends DokuWiki_CLI_Plugin
         $searchOpts = array('depth' => 0, 'skipacl' => true);
 
         $this->log('info', 'Collecting pages...');
+        $pagedata = [];
         search($pagedata, $conf['datadir'], 'search_allpages', $searchOpts);
         $pages = array_column($pagedata, 'id');
         $this->log('info', count($pages) . ' pages found.');
@@ -52,6 +53,7 @@ class cli_plugin_cleanoldips extends DokuWiki_CLI_Plugin
         $this->log('success', 'The page changelogs have been cleaned.');
 
         $this->log('info', 'Collecting media files...');
+        $mediadata = [];
         search($mediadata, $conf['mediadir'], 'search_media', $searchOpts);
         $media = array_column($mediadata, 'id');
         $this->log('info', count($media) . ' media files found.');

--- a/cli.php
+++ b/cli.php
@@ -52,7 +52,7 @@ class cli_plugin_cleanoldips extends DokuWiki_CLI_Plugin
         $this->log('success', 'The page changelogs have been cleaned.');
 
         $this->log('info', 'Collecting media files...');
-        search($mediadata, $conf['mediadir'], 'search_media',$searchOpts);
+        search($mediadata, $conf['mediadir'], 'search_media', $searchOpts);
         $media = array_column($mediadata, 'id');
         $this->log('info', count($media) . ' media files found.');
         $this->log('info', 'Cleaning media changelogs...');
@@ -62,6 +62,4 @@ class cli_plugin_cleanoldips extends DokuWiki_CLI_Plugin
         }
         $this->log('success', 'The media changelogs have been cleaned.');
     }
-
 }
-

--- a/cli.php
+++ b/cli.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * DokuWiki Plugin cleanoldips (CLI Component)
+ *
+ * @license GPL 2 http://www.gnu.org/licenses/gpl-2.0.html
+ * @author  Michael Große <dokuwiki@cosmocode.de>
+ */
+
+
+use splitbrain\phpcli\Options;
+
+class cli_plugin_cleanoldips extends DokuWiki_CLI_Plugin
+{
+
+    /**
+     * Register options and arguments on the given $options object
+     *
+     * @param Options $options
+     *
+     * @return void
+     */
+    protected function setup(Options $options)
+    {
+        $options->setHelp('Clean ips from all changelog entries older than $conf[\'recent_days\']');
+    }
+
+    /**
+     * Your main program
+     *
+     * Arguments and options have been parsed when this is run
+     *
+     * @param Options $options
+     *
+     * @return void
+     */
+    protected function main(Options $options)
+    {
+        global $conf;
+        $searchOpts = array('depth' => 0, 'skipacl' => true);
+
+        $this->log('info', 'Collecting pages...');
+        search($pagedata, $conf['datadir'], 'search_allpages', $searchOpts);
+        $pages = array_column($pagedata, 'id');
+        $this->log('info', count($pages) . ' pages found.');
+        $this->log('info', 'Cleaning page changelogs...');
+        /** @var action_plugin_cleanoldips $action */
+        $action = plugin_load('action', 'cleanoldips');
+        foreach ($pages as $pageid) {
+            $this->log('debug', 'Cleaning changelog for page ' . $pageid);
+            $action->cleanChangelog($pageid, metaFN($pageid, '.changes'));
+        }
+        $this->log('success', 'The page changelogs have been cleaned.');
+
+        $this->log('info', 'Collecting media files...');
+        search($mediadata, $conf['mediadir'], 'search_media',$searchOpts);
+        $media = array_column($mediadata, 'id');
+        $this->log('info', count($media) . ' media files found.');
+        $this->log('info', 'Cleaning media changelogs...');
+        foreach ($media as $mediaid) {
+            $this->log('debug', 'Cleaning changelog for media file ' . $mediaid);
+            $action->cleanChangelog($mediaid, mediaMetaFN($mediaid, '.changes'));
+        }
+        $this->log('success', 'The media changelogs have been cleaned.');
+    }
+
+}
+


### PR DESCRIPTION
The CLI can be used to perform an initial cleaning of all changelogs in the wiki. Especially, since media files are only rarely update so that the changelogs might otherwise remain uncleaned for a long time.

ADJ-169